### PR TITLE
fix: Update supported protocol versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func createVersionsFile(namespace, provider, distPath, repoName, version, domain
 
 	var ver Version
 	ver.Version = version
-	ver.Protocols = []string{"4.0", "5.1"}
+	ver.Protocols = []string{"5.0", "5.1"}
 	ver.Platforms = []Platform{}
 
 	var vers Versions


### PR DESCRIPTION
This pull request makes a minor update to the supported protocols in the `createVersionsFile` function. The protocol version "4.0" has been removed and replaced with "5.0".