### PR TITLE
feat: add linting for pull request titles

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for linting pull request titles. The workflow is designed to ensure that PR titles follow semantic conventions whenever a pull request is created or updated.

CI/CD improvements:

* Added a `.github/workflows/lint-pr.yml` workflow that uses the `amannn/action-semantic-pull-request` action to validate PR titles on events such as opening, reopening, editing, or synchronizing a pull request.