### PR TITLE
feat: add GitHub release workflow with semantic-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,70 @@
+name: Create Github Release
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  #push:
+  #  branches:
+  #    - main
+  workflow_dispatch: {}
+
+jobs:
+  release:
+    name: Create GitHub Release
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Get Current Branch
+        id: get_branch
+        run: |
+          CURR_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "CURRENT_BRANCH=$CURR_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Get Previous Release Version
+        id: get_previous_version
+        run: |
+          LATEST_TAG=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
+          echo "LATEST_TAG=$LATEST_TAG"
+          echo "VERSION=${LATEST_TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Dry Run - Check Next Version
+        id: dry_run
+        run: |
+          npm i -D conventional-changelog-conventionalcommits@8.0.0 semantic-release@24.1.0 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
+          NEW_VERSION=$(npx semantic-release --dry-run | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          
+          if [ -z "$NEW_VERSION" ]; then
+            echo "No version change detected based on commit messages."
+            echo "RELEASE_NEEDED=false" >> $GITHUB_OUTPUT
+          else
+            echo "New version will be: $NEW_VERSION"
+            echo "RELEASE_NEEDED=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.dry_run.outputs.RELEASE_NEEDED == 'true'
+        run: |
+          npm i -D conventional-changelog-conventionalcommits@8.0.0 semantic-release@24.1.0 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
+          npx semantic-release
+          echo "::notice::🎉 Released version v${{ steps.dry_run.outputs.NEW_VERSION }}"
+
+      - name: No Release Needed
+        if: steps.dry_run.outputs.RELEASE_NEEDED != 'true'
+        run: |
+          echo "::notice::No release needed. Commit messages don't indicate any version change."

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,104 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "release": "major",
+            "breaking": true
+          },
+          {
+            "type": "break",
+            "release": "major"
+          },
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": "patch"
+          },
+          {
+            "type": "chore",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": "patch"
+          }
+        ],
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "break",
+              "section": "💥 Breaking Changes"
+            },
+            {
+              "type": "feat",
+              "section": "✨ Features"
+            },
+            {
+              "type": "fix",
+              "section": "🐛 Bug Fixes"
+            },
+            {
+              "type": "docs",
+              "section": "📝 Documentation"
+            },
+            {
+              "type": "chore",
+              "section": "🧹 Chores"
+            },
+            {
+              "type": "refactor",
+              "section": "♻️ Refactors"
+            },
+            {
+              "type": "test",
+              "section": "🧪 Tests"
+            }
+          ]
+        },
+        "writerOpts": {
+          "commitsSort": [
+            "subject",
+            "scope"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": []
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This pull request introduces automated release management using Semantic Release. It adds a GitHub Actions workflow to create releases based on commit messages and a configuration file to define release rules and changelog formatting.

**Release automation setup:**

* Added `.github/workflows/create-release.yml` to automate GitHub releases using Semantic Release. The workflow checks commit messages to determine if a release is needed, calculates the new version, and publishes a release with generated notes.
* Introduced `.releaserc.json` to configure Semantic Release, specifying branch rules, commit message conventions, release types (major, minor, patch), and changelog section formatting.