### PR TITLE
ci: add cache dependency path to go workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -72,6 +72,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+          cache-dependency-path: |
+            go.mod
 
       - name: Import GPG key
         if: steps.dry_run.outputs.RELEASE_NEEDED == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+          cache-dependency-path: |
+            go.mod
       - run: go mod download
       - run: go build -v .
       - name: Run linters
@@ -40,6 +42,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+          cache-dependency-path: |
+            go.mod
       - run: go mod download
       - env:
           TF_ACC: "1"


### PR DESCRIPTION
This pull request makes minor improvements to the GitHub Actions workflows by explicitly specifying the dependency path for Go modules caching. This helps ensure that caching is correctly scoped to the `go.mod` file, which can improve build efficiency and reliability.

Workflow enhancements for Go module caching:

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R75-R76): Added the `cache-dependency-path` option to the `setup-go` step, specifying `go.mod` for more accurate dependency caching.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R25-R26): Added the `cache-dependency-path` option to the `setup-go` step in both the main and Terraform test jobs, specifying `go.mod` for improved caching accuracy. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R25-R26) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R45-R46)