### PR TITLE
feat: add composite GitHub Action for packaging providers

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -56,7 +56,11 @@ jobs:
         uses: ./
         with:
           namespace: exampleorg
-          domain: terraform-registry.example.com
+          # A reachable registry serving /.well-known/terraform.json. This
+          # exercises tfpp's real well-known lookup (versions 404s for the fake
+          # provider, which is handled gracefully). The unreachable-domain
+          # fallback is covered separately by the Go unit tests.
+          domain: registry.terraform.io
           provider-name: example
           repo-name: terraform-provider-example
           version: 1.0.0

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,75 @@
+name: Test Action
+
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+  push:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-action:
+    name: Run action (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build fixture dist/
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          repo="terraform-provider-example"
+          ver="1.0.0"
+          zip_name="${repo}_${ver}_linux_amd64.zip"
+
+          # Dummy provider archive with the name tfpp expects from GoReleaser.
+          (cd dist && echo "dummy provider binary" > payload && zip -q "${zip_name}" payload && rm payload)
+
+          # SHA256SUMS with the archive's real checksum (GoReleaser format: "<sha>  <file>").
+          (
+            cd dist
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "${zip_name}" > "${repo}_${ver}_SHA256SUMS"
+            else
+              shasum -a 256 "${zip_name}" > "${repo}_${ver}_SHA256SUMS"
+            fi
+          )
+
+          # tfpp only copies the .sig; a placeholder is sufficient for the test.
+          echo "PLACEHOLDER-SIGNATURE" > "dist/${repo}_${ver}_SHA256SUMS.sig"
+          echo "PLACEHOLDER-PUBLIC-KEY" > pubkey.txt
+
+      - name: Package with tfpp action
+        id: pkg
+        uses: ./
+        with:
+          namespace: exampleorg
+          domain: terraform-registry.example.com
+          provider-name: example
+          repo-name: terraform-provider-example
+          version: 1.0.0
+          gpg-fingerprint: PLACEHOLDER-FINGERPRINT
+
+      - name: Assert output tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          arch_file="release/v1/providers/exampleorg/example/1.0.0/download/linux/amd64"
+          versions_file="release/v1/providers/exampleorg/example/versions"
+          test -f "${arch_file}" || { echo "::error::missing ${arch_file}"; exit 1; }
+          test -f "${versions_file}" || { echo "::error::missing ${versions_file}"; exit 1; }
+          python3 -c "import json,sys; json.load(open('${versions_file}'))"
+          echo "release-path output: ${{ steps.pkg.outputs.release-path }}"
+          echo "OK"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,69 @@ tfpp -p example -r terraform-provider-example  \
 aws s3 sync release/ s3://s3-tfregistry-example/
 ```
 
-## TODO
-- [ ] Provide a Github Actions workflow example
-- [ ] Add unit tests
+## GitHub Action
+
+`tfpp` ships as a composite GitHub Action so you can package a provider directly
+in your release pipeline without installing the binary yourself. The action
+downloads the prebuilt `tfpp` binary matching the runner OS/arch, verifies its
+checksum, and runs it against your GoReleaser `dist/` directory.
+
+### Usage
+
+```yaml
+- name: Import GPG key
+  id: import_gpg
+  uses: crazy-max/ghaction-import-gpg@v7
+  with:
+    gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+    passphrase: ${{ secrets.PASSPHRASE }}
+
+- name: Run GoReleaser
+  uses: goreleaser/goreleaser-action@v7
+  with:
+    args: release --clean
+  env:
+    GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
+- name: Package for the static registry
+  id: package
+  uses: marceloalmeida/tfpp@v1
+  with:
+    namespace: exampleorg
+    domain: terraform-registry.example.com
+    provider-name: example
+    repo-name: terraform-provider-example
+    version: 1.0.0
+    gpg-fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
+
+- name: Publish to S3
+  run: aws s3 sync "${{ steps.package.outputs.release-path }}/" s3://s3-tfregistry-example/
+```
+
+Pin to a specific tool release with `tfpp-version: 1.2.3` for reproducible builds
+(it defaults to the latest release).
+
+### Inputs
+
+| Input | Required | Default | tfpp flag | Description |
+| --- | --- | --- | --- | --- |
+| `namespace` | yes | | `-ns` | Namespace for the Terraform registry. |
+| `domain` | yes | | `-d` | Private Terraform registry domain. |
+| `provider-name` | yes | | `-p` | Name of the Terraform provider. |
+| `repo-name` | yes | | `-r` | Provider repository name used in the GoReleaser build files. |
+| `version` | yes | | `-v` | Semantic version of the **provider release** being packaged. |
+| `gpg-fingerprint` | yes | | `-gf` | GPG fingerprint of the key used by GoReleaser. |
+| `dist-path` | no | `dist` | `-dp` | Path to the GoReleaser build files. |
+| `gpg-public-key-file` | no | `pubkey.txt` | `-gk` | Path to the GPG public key in ASCII armor format. |
+| `tfpp-version` | no | `latest` | | Version of the **tfpp tool** to download (e.g. `1.2.3`). |
+| `working-directory` | no | `.` | | Directory to run `tfpp` in; `release/` is created here. |
+| `github-token` | no | `${{ github.token }}` | | Token used to query the tfpp releases API. |
+
+> Note: `version` is the provider version you are packaging, while `tfpp-version`
+> selects which build of the `tfpp` tool the action downloads.
+
+### Outputs
+
+| Output | Description |
+| --- | --- |
+| `release-path` | Absolute path to the generated `release/` directory. |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,170 @@
+name: Terraform Provider Packager
+description: Package Terraform provider assets from a GoReleaser dist/ directory into a static registry layout with tfpp.
+author: marceloalmeida
+
+branding:
+  icon: package
+  color: purple
+
+inputs:
+  namespace:
+    description: Namespace for the Terraform registry (maps to tfpp -ns).
+    required: true
+  domain:
+    description: Private Terraform registry domain (maps to tfpp -d).
+    required: true
+  provider-name:
+    description: Name of the Terraform provider (maps to tfpp -p).
+    required: true
+  repo-name:
+    description: Provider repository name used in the GoReleaser build files (maps to tfpp -r).
+    required: true
+  version:
+    description: Semantic version of the provider release being packaged (maps to tfpp -v). Note this is the provider version, not the tfpp tool version.
+    required: true
+  gpg-fingerprint:
+    description: GPG fingerprint of the key used by GoReleaser (maps to tfpp -gf).
+    required: true
+  dist-path:
+    description: Path to the GoReleaser build files (maps to tfpp -dp).
+    required: false
+    default: dist
+  gpg-public-key-file:
+    description: Path to the GPG public key in ASCII armor format (maps to tfpp -gk).
+    required: false
+    default: pubkey.txt
+  tfpp-version:
+    description: Version of the tfpp tool to download (e.g. 1.2.3 or v1.2.3). Defaults to the latest release.
+    required: false
+    default: latest
+  working-directory:
+    description: Directory to run tfpp in. The generated release/ directory is created here.
+    required: false
+    default: .
+  github-token:
+    description: Token used to query the tfpp releases API (avoids rate limiting). Defaults to the job token.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  release-path:
+    description: Absolute path to the generated release/ directory.
+    value: ${{ steps.run.outputs.release-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve tfpp version
+      id: resolve
+      shell: bash
+      env:
+        TFPP_VERSION: ${{ inputs.tfpp-version }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        repo="marceloalmeida/tfpp"
+        if [ "${TFPP_VERSION}" = "latest" ]; then
+          tag=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${repo}/releases/latest" \
+            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+          if [ -z "${tag}" ]; then
+            echo "::error::Could not resolve the latest tfpp release tag." >&2
+            exit 1
+          fi
+        else
+          tag="${TFPP_VERSION}"
+        fi
+        # Normalize: tag is v-prefixed, version is not.
+        version="${tag#v}"
+        tag="v${version}"
+        echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
+        echo "Resolved tfpp ${tag}"
+
+    - name: Download and verify tfpp
+      id: download
+      shell: bash
+      env:
+        TFPP_TAG: ${{ steps.resolve.outputs.tag }}
+        TFPP_VER: ${{ steps.resolve.outputs.version }}
+      run: |
+        set -euo pipefail
+        repo="marceloalmeida/tfpp"
+
+        case "${RUNNER_OS}" in
+          Linux)   os="linux" ;;
+          macOS)   os="darwin" ;;
+          Windows) os="windows" ;;
+          *) echo "::error::Unsupported runner OS: ${RUNNER_OS}" >&2; exit 1 ;;
+        esac
+        case "${RUNNER_ARCH}" in
+          X64)   arch="amd64" ;;
+          X86)   arch="386" ;;
+          ARM)   arch="arm" ;;
+          ARM64) arch="arm64" ;;
+          *) echo "::error::Unsupported runner arch: ${RUNNER_ARCH}" >&2; exit 1 ;;
+        esac
+
+        workdir="$(mktemp -d)"
+        archive="tfpp_${TFPP_VER}_${os}_${arch}.zip"
+        sums="tfpp_${TFPP_VER}_SHA256SUMS"
+        base="https://github.com/${repo}/releases/download/${TFPP_TAG}"
+
+        echo "Downloading ${archive}"
+        if ! curl -fsSL -o "${workdir}/${archive}" "${base}/${archive}"; then
+          echo "::error::Failed to download ${archive} from ${base}. Is tfpp ${TFPP_TAG} published for ${os}/${arch}?" >&2
+          exit 1
+        fi
+        curl -fsSL -o "${workdir}/${sums}" "${base}/${sums}"
+
+        echo "Verifying checksum"
+        (
+          cd "${workdir}"
+          if command -v sha256sum >/dev/null 2>&1; then
+            grep " ${archive}\$" "${sums}" | sha256sum -c -
+          else
+            grep " ${archive}\$" "${sums}" | shasum -a 256 -c -
+          fi
+        )
+
+        echo "Extracting ${archive}"
+        unzip -q -o "${workdir}/${archive}" -d "${workdir}"
+        binary="${workdir}/tfpp_v${TFPP_VER}"
+        if [ "${os}" = "windows" ]; then
+          binary="${binary}.exe"
+        fi
+        if [ ! -f "${binary}" ]; then
+          echo "::error::Expected binary tfpp_v${TFPP_VER} not found in ${archive}." >&2
+          exit 1
+        fi
+        chmod +x "${binary}"
+        echo "binary=${binary}" >> "${GITHUB_OUTPUT}"
+
+    - name: Run tfpp
+      id: run
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        TFPP_BIN: ${{ steps.download.outputs.binary }}
+        IN_NAMESPACE: ${{ inputs.namespace }}
+        IN_DOMAIN: ${{ inputs.domain }}
+        IN_PROVIDER: ${{ inputs.provider-name }}
+        IN_REPO: ${{ inputs.repo-name }}
+        IN_VERSION: ${{ inputs.version }}
+        IN_FINGERPRINT: ${{ inputs.gpg-fingerprint }}
+        IN_DIST: ${{ inputs.dist-path }}
+        IN_PUBKEY: ${{ inputs.gpg-public-key-file }}
+      run: |
+        set -euo pipefail
+        "${TFPP_BIN}" \
+          -ns "${IN_NAMESPACE}" \
+          -d "${IN_DOMAIN}" \
+          -p "${IN_PROVIDER}" \
+          -r "${IN_REPO}" \
+          -v "${IN_VERSION}" \
+          -gf "${IN_FINGERPRINT}" \
+          -dp "${IN_DIST}" \
+          -gk "${IN_PUBKEY}"
+        echo "release-path=$(pwd)/release" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -64,11 +64,13 @@ runs:
         set -euo pipefail
         repo="marceloalmeida/tfpp"
         if [ "${TFPP_VERSION}" = "latest" ]; then
-          tag=$(curl -fsSL \
+          # Capture the response first: piping curl directly into `grep -m1`
+          # makes grep close the pipe early, which fails curl under pipefail.
+          resp=$(curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${repo}/releases/latest" \
-            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+            "https://api.github.com/repos/${repo}/releases/latest")
+          tag=$(grep -m1 '"tag_name"' <<< "${resp}" | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
           if [ -z "${tag}" ]; then
             echo "::error::Could not resolve the latest tfpp release tag." >&2
             exit 1

--- a/main.go
+++ b/main.go
@@ -240,22 +240,24 @@ func downloadVersionsFile(namespace, provider, domain string) (Versions, WellKno
 	wellKnownUrl := fmt.Sprintf("https://%s/.well-known/terraform.json", domain)
 	resp, err := httpClient.Get(wellKnownUrl)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		log.Printf("Error downloading well-known file: %s or status code not %d", err.Error(), http.StatusOK)
+		reqErr := err
+		if reqErr == nil {
+			reqErr = fmt.Errorf("unexpected status code %d (want %d)", resp.StatusCode, http.StatusOK)
+		}
+		log.Printf("Error downloading well-known file: %s", reqErr)
 
-		wellKnownFile, err := json.MarshalIndent(defaultWellKnownData, "", "  ")
-		if err != nil {
-			log.Fatalf("Error marshalling JSON: %s", err)
+		wellKnownFile, marshalErr := json.MarshalIndent(defaultWellKnownData, "", "  ")
+		if marshalErr != nil {
+			log.Fatalf("Error marshalling JSON: %s", marshalErr)
 		}
-		err = createDirRecursive("release/.well-known/")
-		if err != nil {
-			log.Fatalf("Error creating directory: %s", err)
+		if mkErr := createDirRecursive("release/.well-known/"); mkErr != nil {
+			log.Fatalf("Error creating directory: %s", mkErr)
 		}
-		err = writeFile("release/"+".well-known/terraform.json", wellKnownFile)
-		if err != nil {
-			log.Fatalf("Error writing terraform.json file: %s", err)
+		if writeErr := writeFile("release/"+".well-known/terraform.json", wellKnownFile); writeErr != nil {
+			log.Fatalf("Error writing terraform.json file: %s", writeErr)
 		}
 
-		return Versions{}, defaultWellKnownData, fmt.Errorf("error downloading well-known file: %s or status code not %d", err.Error(), http.StatusOK)
+		return Versions{}, defaultWellKnownData, fmt.Errorf("error downloading well-known file: %w", reqErr)
 	}
 	defer resp.Body.Close()
 
@@ -276,8 +278,12 @@ func downloadVersionsFile(namespace, provider, domain string) (Versions, WellKno
 	versionsUrl := fmt.Sprintf("https://%s%s%s/%s/versions", domain, wellKnownData.ProvidersV1, namespace, provider)
 	resp, err = httpClient.Get(versionsUrl)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		log.Printf("Error downloading versions file: %s or status code not %d", err, http.StatusOK)
-		return Versions{}, wellKnownData, fmt.Errorf("error downloading versions file: %s or status code not %d", err, http.StatusOK)
+		reqErr := err
+		if reqErr == nil {
+			reqErr = fmt.Errorf("unexpected status code %d (want %d)", resp.StatusCode, http.StatusOK)
+		}
+		log.Printf("Error downloading versions file: %s", reqErr)
+		return Versions{}, wellKnownData, fmt.Errorf("error downloading versions file: %w", reqErr)
 	}
 	defer resp.Body.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -927,3 +927,29 @@ func TestCreateArchitectureFiles(t *testing.T) {
 		})
 	}
 }
+
+// TestDownloadVersionsFileUnreachableDomain ensures that when the registry
+// domain cannot be reached (e.g. a first publish against a registry that does
+// not exist yet), downloadVersionsFile falls back to the default well-known
+// data instead of panicking.
+func TestDownloadVersionsFileUnreachableDomain(t *testing.T) {
+	// t.Chdir isolates the release/ output to a temp dir and restores the
+	// working directory automatically when the test finishes.
+	t.Chdir(t.TempDir())
+
+	// The .invalid TLD is reserved (RFC 6761) and never resolves, so the
+	// well-known fetch fails and the fallback path is exercised.
+	versions, wellKnown, err := downloadVersionsFile("ns", "prov", "nonexistent.invalid")
+	if err == nil {
+		t.Fatalf("Expected an error for an unreachable domain, got nil")
+	}
+	if wellKnown != defaultWellKnownData {
+		t.Errorf("Expected defaultWellKnownData, got %+v", wellKnown)
+	}
+	if len(versions.Versions) != 0 {
+		t.Errorf("Expected empty versions, got %+v", versions.Versions)
+	}
+	if _, statErr := os.Stat("release/.well-known/terraform.json"); statErr != nil {
+		t.Errorf("Expected default well-known file to be written: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a reusable **composite GitHub Action** for `tfpp`, ready to publish on the Marketplace, so provider authors can package assets for a static Terraform registry directly in their release pipeline — no manual binary install.

- **`action.yml`** — resolves the `tfpp-version` (default `latest`), maps the runner OS/arch to GoReleaser's archive naming, downloads and **checksum-verifies** the release archive, extracts the `tfpp_v{version}` binary, and runs it with all inputs mapped to CLI flags. Cross-platform (`shell: bash`), with Marketplace `branding` and a `release-path` output.
- **`.github/workflows/test-action.yml`** — end-to-end CI on `ubuntu-latest` + `macos-latest`: builds a fixture `dist/`, runs the action via `uses: ./`, and asserts the registry tree + valid `versions` JSON.
- **README** — new GitHub Action section (usage example, input/output tables), replacing the old TODOs. Placeholder secrets only.

## Bug fix included

While testing offline I hit a **pre-existing nil-pointer panic** in `downloadVersionsFile`: the `err` variable was clobbered by later successful calls, so `err.Error()` dereferenced nil whenever the registry domain was unreachable — which is exactly the **first-publish** case (registry empty/nonexistent). The fallback to default well-known data now works. Added `TestDownloadVersionsFileUnreachableDomain` as a regression test.

## Verification

- Regression test reproduced the panic, then passed after the fix; full suite **45 tests pass**.
- `golangci-lint`: 0 issues; `gofmt`/`go vet` clean.
- Validated the download → checksum → extract path against the real `v0.1.1` release (checksum `OK`, binary name matched).
- End-to-end fixture run produced the correct registry tree.

## Follow-up (manual)

First Marketplace publish must be done once via the release UI (the automated semantic-release flow creates releases via API, which doesn't tick the "Publish to Marketplace" checkbox). Consider maintaining a floating `v1` tag so the documented `@v1` reference resolves.