### PR TITLE
ci: maintain floating major version tag on release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -98,6 +98,26 @@ jobs:
           npx semantic-release
           echo "::notice::🎉 Released version v${{ steps.dry_run.outputs.NEW_VERSION }}"
 
+      - name: Update major version tag
+        if: steps.dry_run.outputs.RELEASE_NEEDED == 'true'
+        env:
+          NEW_VERSION: ${{ steps.dry_run.outputs.NEW_VERSION }}
+        run: |
+          set -euo pipefail
+          MAJOR="${NEW_VERSION%%.*}"
+          # Pre-1.0 minors can be breaking, so a floating v0 tag would be
+          # misleading; only maintain the major tag from v1.0.0 onwards.
+          if [ "${MAJOR}" -lt 1 ]; then
+            echo "::notice::Skipping major tag for pre-1.0 release v${NEW_VERSION}."
+            exit 0
+          fi
+          # semantic-release tags the current commit and makes no new commits,
+          # so HEAD is the released commit. Move the floating vN tag there so
+          # consumers can pin the action with @vN.
+          git tag -f "v${MAJOR}"
+          git push -f origin "v${MAJOR}"
+          echo "::notice::Updated v${MAJOR} -> v${NEW_VERSION}"
+
       - name: No Release Needed
         if: steps.dry_run.outputs.RELEASE_NEEDED != 'true'
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #37. Automatically moves the floating `vN` tag to each released commit so consumers can pin the action with `@vN` (e.g. `uses: marceloalmeida/tfpp@v1`, as documented in the README).

## Why in the release job (not a separate workflow)

Releases are created by `semantic-release` using the default `GITHUB_TOKEN`, and **actions authenticated with `GITHUB_TOKEN` do not trigger downstream workflows**. A separate workflow listening on `release: published` would therefore never fire. Doing the tag move in the same job that creates the release is the reliable, PAT-free approach.

## Behaviour

- Runs only when a release is actually cut (`RELEASE_NEEDED == 'true'`).
- Skips pre-1.0 releases — `0.x` minors may be breaking, so a floating `v0` tag would be misleading. The `vN` tag starts at `v1.0.0`.
- `semantic-release` makes no commits, so `HEAD` is the released commit; the tag is force-moved there and force-pushed. The job already has `contents: write`.

## Verification

- YAML validated.
- Major-extraction + guard logic checked across `0.1.1 / 0.9.0 / 1.0.0 / 2.3.4 / 10.0.0` (skips `v0.x`, moves `v1`/`v2`/`v10`).